### PR TITLE
Handle PROCSIG_BARRIER

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -65,7 +65,7 @@ jobs:
     - name: Run tests
       run: |
         PATH=/usr/lib/postgresql/$PG/bin:$PATH bash -x test.sh
-        if grep -E '(ERROR|FATAL)' test_cluster?/pg_log/postgresql.log | grep -Ev '(no COPY in progress|could not connect to|could not send|the database system is not yet accepting connections|database system is shutting|error reading result of streaming command|database system is starting up|log:noisia)'; then exit 1; fi
+        if grep -E '(ERROR|FATAL)' test_cluster?/pg_log/postgresql.log | grep -Ev '(no COPY in progress|could not connect to|could not send|the database system is not yet accepting connections|database system is shutting|error reading result of streaming command|database system is starting up|log:noisia|terminating connection due to administrator command)'; then exit 1; fi
 
     - name: Generate lcov.info
       run: |

--- a/bg_mon.c
+++ b/bg_mon.c
@@ -14,6 +14,7 @@
 #include "storage/ipc.h"
 #include "storage/latch.h"
 #include "storage/proc.h"
+#include "storage/procsignal.h"
 
 /* these headers are used by this particular worker's code */
 #include "pgstat.h"
@@ -709,6 +710,7 @@ bg_mon_main(Datum main_arg)
 	/* Establish signal handlers before unblocking signals. */
 	pqsignal(SIGHUP, bg_mon_sighup);
 	pqsignal(SIGTERM, bg_mon_sigterm);
+	pqsignal(SIGUSR1, procsignal_sigusr1_handler); // as we don't set BGWORKER_BACKEND_DATABASE_CONNECTION
 
 	if (signal(SIGPIPE, SIG_IGN) == SIG_ERR)
 		proc_exit(1);

--- a/bg_mon.c
+++ b/bg_mon.c
@@ -791,6 +791,9 @@ restart:
 					   naptime);
 #endif
 		ResetLatch(MyLatch);
+
+		CHECK_FOR_INTERRUPTS();
+
 		/* emergency bailout if postmaster has died */
 		if (rc & WL_POSTMASTER_DEATH)
 			proc_exit(1);


### PR DESCRIPTION
Set SIGUSR1 handler explicitly and call CHECK_FOR_INTERRUPTS() after resetting Latch.

Currently bg_mon doesn't handle SIGUSR1 at all, which wasn't a problem until https://github.com/postgres/postgres/commit/4eb2176 appeared. It means that unless we handle PROCSIG_BARRIER drop tablespace/database can not work correctly.
procsignal_sigusr1_handler is [automatically](https://github.com/postgres/postgres/blob/REL_15_STABLE/src/backend/postmaster/bgworker.c#L764) set for a bgworker that defines BGWORKER_BACKEND_DATABASE_CONNECTION flag, however it is not done in bg_mon [for a reason](https://github.com/CyberDem0n/bg_mon/commit/c7b5e86dcf58b42670e8254e0ba408db210d8bea).